### PR TITLE
Store spectators with names and steam id instead of just steam id.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@austenke/due-process-stat-parser",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Library for parsing player stats from Due Process log files",
   "main": "lib/index.js",
   "scripts": {

--- a/src/events.ts
+++ b/src/events.ts
@@ -27,7 +27,7 @@ export class DamageEvent extends GameEvent {
     }
 }
 
-export class KillEvent extends GameEvent {
+export class KillEvent extends GameEvent { // eslint-disable-next-line
     constructor(json: any) {
         super(json);
     }

--- a/src/logParser.ts
+++ b/src/logParser.ts
@@ -24,31 +24,8 @@ export class LogParser {
         let fileLines = data.split("\n");
         let matches: Match[] = [];
         let currentMatch: Match | undefined;
-        let accountId: string | undefined;
-
+        
         fileLines.forEach((line: string) => {
-            let gecnet = line.match(LogParser.GECNET_MESSAGE);
-            if (gecnet && gecnet[0]) {
-                let json = JSON.parse(gecnet[1]);
-                if (json.data) {
-                    if (json.type === "myProfile") {
-                        let data = JSON.parse(json.data);
-                        accountId = data.AccountId;
-                    } else if (json.type === "updateMatchScore") {
-                        let data = JSON.parse(json.data);
-                        if (accountId && (data.Team1Members.includes(accountId) || data.Team2Members.includes(accountId))) {
-                            data.Spectators.forEach((spectator: string) => {
-                                if (!currentMatch?.spectators.includes(spectator)) {
-                                    currentMatch?.spectators.push(spectator);
-                                    console.log("Added " + spectator + " to current match");
-                                }
-                            });
-                        }
-                    }
-                }
-                return;
-            }
-
             let reset = line.match(LogParser.RESET_REGEX);
             if (reset && reset[0]) {
                 if (currentMatch) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -259,7 +259,7 @@ export class Match {
 
     public events: {[round: number]: GameEvent[]} = {};
 
-    public spectators: string[] = [];
+    public spectators: {[steamId: string]: string} = {};
 
     constructor(matchId: number) {
         this.matchId = matchId;
@@ -281,7 +281,9 @@ export class Match {
         } else if (team === 1) {
             this.updateTeam(this.team2, teamEvent);
         } else {
-            console.log("Ignoring team " + team);
+            teamEvent.members.forEach((member: Member) => {
+                this.spectators[member.accountId] = member.name;
+            });
         }
     }
 


### PR DESCRIPTION
Use the already parsed stats logs to keep track of spectators and their names.